### PR TITLE
allow for extra cli arguments

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 import start from './';
 
-if (process.argv.length !== 4) {
+if (process.argv.length < 4) {
     throw new Error('Usage: start <tasks file> <task name>');
 }
 


### PR DESCRIPTION
I have a need to pass additional arguments to a task. For example I would like to set a `--release` flag to trigger build in production mode. Here's how this might look:

```
  "scripts": {
    "task": "babel-node node_modules/.bin/start tasks/",
    "build": "npm run task build",
    "build:prod": "npm run build -- --release"
  }
```
