### PR TITLE
Spread user options after default values

### DIFF
--- a/packages/plugin-find/src/index.ts
+++ b/packages/plugin-find/src/index.ts
@@ -6,11 +6,11 @@ export default (glob: string | string[], userOptions?: {}) =>
 
     const options = {
       ignore: ['node_modules/**'],
-      ...userOptions,
       deep: true,
       onlyFiles: false,
       expandDirectories: false,
-      absolute: true
+      absolute: true,
+      ...userOptions
     }
     const result = await globby(glob, options)
 


### PR DESCRIPTION
The user options were spread before default values. This way the user couldn't overwrite default ones (such as `onlyFiles`).